### PR TITLE
modify commandline flag options

### DIFF
--- a/turbogenius/turbo_genius_cli.py
+++ b/turbogenius/turbo_genius_cli.py
@@ -365,7 +365,7 @@ def makefort10(
 @cli.command(short_help="convertfort10mol_genius")
 @decorate_grpost
 @click.option(
-    "--random_mo",
+    "--random_mo/--no-random_mo",
     "add_random_mo",
     help="flag for adding random MOs",
     is_flag=True,
@@ -993,7 +993,7 @@ def vmc(
 @cli.command(short_help="readforward_genius")
 @decorate_grpost
 @click.option(
-    "-corr",
+    "-corr/-no-corr",
     "corr_sampling",
     help="correlated sampling",
     is_flag=True,


### PR DESCRIPTION
the command line options that behave as flags (is_flag=True) and whose default values are True are modified.

- modify option names to "--random_mo/--no-random_mo" so that the enabled/disabled cases are explicitly specified.
- note that the meaning of specifying the option is reversed: 
  - (previous)
    - without --random_mo, the variable *add_random_mo* is True (default)
    - by specifying --random_mo, *add_random_mo* is False
  - (new)
    - without the option, *add_random_mo* is True (default)
    - by specifying --random_mo, *add_random_mo* is True
    - by specifying --no-random_mo, *add_random_mo* is False